### PR TITLE
Add item management system

### DIFF
--- a/TextLifeRpg.sln.DotSettings.user
+++ b/TextLifeRpg.sln.DotSettings.user
@@ -5,4 +5,7 @@
 &lt;/SessionState&gt;</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=5c703331_002D5e5b_002D4598_002D8c4f_002Ddffc810d0803/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;test&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Project Location="C:\Users\fabien.dumont\RiderProjects\TextLifeRpg" Presentation="&amp;lt;test&amp;gt;" /&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=e53b2b90_002D2284_002D467d_002Db44b_002D15d1608c6799/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="ItemTests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Project Location="C:\Users\fabien.dumont\RiderProjects\TextLifeRpg" Presentation="&amp;lt;test&amp;gt;" /&gt;&#xD;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/src/TextLifeRpg.Application/Abstraction/IItemService.cs
+++ b/src/TextLifeRpg.Application/Abstraction/IItemService.cs
@@ -1,0 +1,36 @@
+﻿using TextLifeRpg.Domain;
+
+namespace TextLifeRpg.Application.Abstraction;
+
+/// <summary>
+/// Service interface for managing items.
+/// </summary>
+public interface IItemService
+{
+  #region Methods
+
+  /// <summary>
+  /// Retrieve an item from a given identifier.
+  /// </summary>
+  /// <param name="id">The item identifier.</param>
+  /// <param name="cancellationToken">A cancellation token.</param>
+  /// <returns>The corresponding item.</returns>
+  Task<Item?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Retrieve an item from a given name.
+  /// </summary>
+  /// <param name="name">The item name.</param>
+  /// <param name="cancellationToken">A cancellation token.</param>
+  /// <returns>The corresponding item.</returns>
+  Task<Item?> GetByNameAsync(string name, CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Retrieves all available items.
+  /// </summary>
+  /// <param name="cancellationToken">A cancellation token.</param>
+  /// <returns>A read-only collection of items.</returns>
+  Task<IReadOnlyCollection<Item>> GetAllAsync(CancellationToken cancellationToken);
+
+  #endregion
+}

--- a/src/TextLifeRpg.Application/Abstraction/IJobService.cs
+++ b/src/TextLifeRpg.Application/Abstraction/IJobService.cs
@@ -14,7 +14,7 @@ public interface IJobService
   /// </summary>
   /// <param name="id">The job identifier.</param>
   /// <param name="cancellationToken">A cancellation token.</param>
-  /// <returns>The corresponding trait.</returns>
+  /// <returns>The corresponding job.</returns>
   Task<Job?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 
   /// <summary>
@@ -22,7 +22,7 @@ public interface IJobService
   /// </summary>
   /// <param name="name">The job name.</param>
   /// <param name="cancellationToken">A cancellation token.</param>
-  /// <returns>The corresponding trait.</returns>
+  /// <returns>The corresponding job.</returns>
   Task<Job?> GetByNameAsync(string name, CancellationToken cancellationToken);
 
   /// <summary>

--- a/src/TextLifeRpg.Application/Abstraction/Repositories/IItemRepository.cs
+++ b/src/TextLifeRpg.Application/Abstraction/Repositories/IItemRepository.cs
@@ -1,0 +1,34 @@
+﻿using TextLifeRpg.Domain;
+
+namespace TextLifeRpg.Application.Abstraction.Repositories;
+
+/// <summary>
+/// Repository interface for items.
+/// </summary>
+public interface IItemRepository
+{
+  #region Methods
+
+  /// <summary>
+  /// Retrieve an item from a given identifier.
+  /// </summary>
+  /// <param name="id">The item identifier.</param>
+  /// <param name="cancellationToken">A cancellation token.</param>
+  /// <returns>The corresponding item.</returns>
+  Task<Item?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Retrieve an item from a given name.
+  /// </summary>
+  /// <param name="name">The item name.</param>
+  /// <param name="cancellationToken">A cancellation token.</param>
+  /// <returns>The corresponding item.</returns>
+  Task<Item?> GetByNameAsync(string name, CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Retrieves all available items.
+  /// </summary>
+  Task<IReadOnlyCollection<Item>> GetAllAsync(CancellationToken cancellationToken);
+
+  #endregion
+}

--- a/src/TextLifeRpg.Application/Abstraction/Repositories/IJobRepository.cs
+++ b/src/TextLifeRpg.Application/Abstraction/Repositories/IJobRepository.cs
@@ -3,7 +3,7 @@
 namespace TextLifeRpg.Application.Abstraction.Repositories;
 
 /// <summary>
-/// Repository interface for traits.
+/// Repository interface for jobs.
 /// </summary>
 public interface IJobRepository
 {
@@ -22,7 +22,7 @@ public interface IJobRepository
   /// </summary>
   /// <param name="name">The job name.</param>
   /// <param name="cancellationToken">A cancellation token.</param>
-  /// <returns>The corresponding trait.</returns>
+  /// <returns>The corresponding job.</returns>
   Task<Job?> GetByNameAsync(string name, CancellationToken cancellationToken);
 
   /// <summary>

--- a/src/TextLifeRpg.Application/ServiceCollectionExtensions.cs
+++ b/src/TextLifeRpg.Application/ServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ServiceCollectionExtensions
     services.AddScoped<IExplorationActionResultService, ExplorationActionResultService>();
     services.AddScoped<IExplorationActionResultNarrationService, ExplorationActionResultNarrationService>();
     services.AddScoped<IJobService, JobService>();
+    services.AddScoped<IItemService, ItemService>();
   }
 
   #endregion

--- a/src/TextLifeRpg.Application/Services/ItemService.cs
+++ b/src/TextLifeRpg.Application/Services/ItemService.cs
@@ -1,0 +1,33 @@
+﻿using TextLifeRpg.Application.Abstraction;
+using TextLifeRpg.Application.Abstraction.Repositories;
+using TextLifeRpg.Domain;
+
+namespace TextLifeRpg.Application.Services;
+
+/// <summary>
+/// Service for managing items.
+/// </summary>
+public class ItemService(IItemRepository itemRepository) : IItemService
+{
+  #region Implmentation of IItemService
+
+  /// <inheritdoc />
+  public async Task<Item?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+  {
+    return await itemRepository.GetByIdAsync(id, cancellationToken);
+  }
+
+  /// <inheritdoc />
+  public async Task<Item?> GetByNameAsync(string name, CancellationToken cancellationToken)
+  {
+    return await itemRepository.GetByNameAsync(name, cancellationToken);
+  }
+
+  /// <inheritdoc />
+  public async Task<IReadOnlyCollection<Item>> GetAllAsync(CancellationToken cancellationToken)
+  {
+    return await itemRepository.GetAllAsync(cancellationToken);
+  }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Domain/Character.cs
+++ b/src/TextLifeRpg.Domain/Character.cs
@@ -79,6 +79,11 @@ public class Character
   /// </summary>
   public Guid? JobId { get; set; }
 
+  /// <summary>
+  /// The character's inventory entries.
+  /// </summary>
+  public List<InventoryEntry> InventoryEntries { get; } = [];
+
   #endregion
 
   #region Ctors
@@ -167,6 +172,53 @@ public class Character
   public void SetJob(Guid jobId)
   {
     JobId = jobId;
+  }
+
+  /// <summary>
+  /// Adds inventory entries to the character's inventory.
+  /// </summary>
+  public void AddInventoryEntries(IEnumerable<InventoryEntry> inventoryEntries)
+  {
+    InventoryEntries.AddRange(inventoryEntries);
+  }
+
+  /// <summary>
+  /// Adds an item to the character's inventory or updates the quantity if the item already exists in the inventory.
+  /// </summary>
+  /// <param name="itemId">The unique identifier of the item to be added to the inventory.</param>
+  /// <param name="quantity">The quantity of the item to be added.</param>
+  public void AddItemToInventory(Guid itemId, int quantity)
+  {
+    var entry = InventoryEntries.FirstOrDefault(i => i.ItemId == itemId);
+    if (entry != null)
+    {
+      entry.Add(quantity);
+    }
+    else
+    {
+      InventoryEntries.Add(InventoryEntry.Create(itemId, quantity));
+    }
+  }
+
+  /// <summary>
+  /// Removes a specified quantity of an item from the character's inventory.
+  /// If the item's quantity reaches zero, the item is removed from the inventory.
+  /// </summary>
+  /// <param name="itemId">The unique identifier of the item to be removed.</param>
+  /// <param name="quantity">The amount of the item to be removed from the inventory.</param>
+  public void RemoveItemFromInventory(Guid itemId, int quantity)
+  {
+    var entry = InventoryEntries.FirstOrDefault(i => i.ItemId == itemId);
+    if (entry == null)
+    {
+      return;
+    }
+
+    entry.Remove(quantity);
+    if (entry.Quantity == 0)
+    {
+      InventoryEntries.Remove(entry);
+    }
   }
 
   #endregion

--- a/src/TextLifeRpg.Domain/InventoryEntry.cs
+++ b/src/TextLifeRpg.Domain/InventoryEntry.cs
@@ -1,0 +1,67 @@
+﻿namespace TextLifeRpg.Domain;
+
+/// <summary>
+/// Represents an entry in the inventory, containing details of a specific item and its quantity.
+/// </summary>
+public class InventoryEntry
+{
+  #region Properties
+
+  /// <summary>
+  /// Gets the unique identifier of the item associated with this inventory entry.
+  /// </summary>
+  public Guid ItemId { get; }
+
+  /// <summary>
+  /// Represents the quantity of an item in the inventory.
+  /// Determines the number of units of a specific item contained within an inventory entry.
+  /// </summary>
+  public int Quantity { get; private set; }
+
+  #endregion
+
+  #region Ctors
+
+  /// <summary>
+  /// Private constructor used internally.
+  /// </summary>
+  private InventoryEntry(Guid itemId, int quantity)
+  {
+    ItemId = itemId;
+    Quantity = quantity;
+  }
+
+  #endregion
+
+  #region Methods
+
+  /// <summary>
+  /// Factory method to create a new instance.
+  /// </summary>
+  public static InventoryEntry Create(Guid itemId, int quantity)
+  {
+    return new InventoryEntry(itemId, quantity);
+  }
+
+  /// <summary>
+  /// Adds a specified amount to the quantity of the inventory entry.
+  /// </summary>
+  /// <param name="amount">The amount to be added. Must be greater than zero.</param>
+  public void Add(int amount)
+  {
+    Quantity += amount;
+  }
+
+  /// <summary>
+  /// Removes a specified amount from the current quantity.
+  /// If the amount to remove is less than or equal to zero, the operation is ignored.
+  /// If the amount to remove exceeds the current quantity, the quantity is set to zero.
+  /// </summary>
+  /// <param name="amount">The number of items to be removed. Must be a positive integer.</param>
+  public void Remove(int amount)
+  {
+    Quantity = Math.Max(0, Quantity - amount);
+  }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Domain/Item.cs
+++ b/src/TextLifeRpg.Domain/Item.cs
@@ -1,0 +1,54 @@
+﻿namespace TextLifeRpg.Domain;
+
+/// <summary>
+/// Domain class representing an item in the game.
+/// </summary>
+public class Item
+{
+  #region Properties
+
+  /// <summary>
+  /// Unique identifier.
+  /// </summary>
+  public Guid Id { get; }
+
+  /// <summary>
+  /// Unique identifier.
+  /// </summary>
+  public string Name { get; }
+
+  #endregion
+
+  #region Ctors
+
+  /// <summary>
+  /// Private constructor used internally.
+  /// </summary>
+  private Item(Guid id, string name)
+  {
+    Id = id;
+    Name = name;
+  }
+
+  #endregion
+
+  #region Methods
+
+  /// <summary>
+  /// Factory method to create a new instance.
+  /// </summary>
+  public static Item Create(string name)
+  {
+    return new Item(Guid.NewGuid(), name);
+  }
+
+  /// <summary>
+  /// Factory method to load an existing instance from persistence.
+  /// </summary>
+  public static Item Load(Guid id, string name)
+  {
+    return new Item(id, name);
+  }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Infrastructure/ApplicationContext.cs
+++ b/src/TextLifeRpg.Infrastructure/ApplicationContext.cs
@@ -78,6 +78,11 @@ public class ApplicationContext : DbContext
   /// </summary>
   public virtual DbSet<JobDataModel> Jobs { get; init; }
 
+  /// <summary>
+  /// Represents all items in the database.
+  /// </summary>
+  public virtual DbSet<ItemDataModel> Items { get; init; }
+
   #endregion
 
   #region Ctors
@@ -117,7 +122,8 @@ public class ApplicationContext : DbContext
       new LocationSeeder(),
       new ExplorationActionSeeder(),
       new NarrationSeeder(),
-      new JobSeeder()
+      new JobSeeder(),
+      new ItemSeeder()
     };
 
     foreach (var seeder in seeders)

--- a/src/TextLifeRpg.Infrastructure/EfDataModels/ItemDataModel.cs
+++ b/src/TextLifeRpg.Infrastructure/EfDataModels/ItemDataModel.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace TextLifeRpg.Infrastructure.EfDataModels;
+
+/// <summary>
+/// EF Core data model representing an item.
+/// </summary>
+[Table("Items")]
+[PrimaryKey(nameof(Id))]
+[Index(nameof(Name), IsUnique = true)]
+public class ItemDataModel
+{
+  #region Properties
+
+  /// <summary>
+  /// Unique identifier.
+  /// </summary>
+  [Column("Id", Order = 1)]
+  [Required]
+  public Guid Id { get; set; }
+
+  /// <summary>
+  /// Name of the trait.
+  /// </summary>
+  [Column("Name", Order = 2)]
+  [Required]
+  [MaxLength(100)]
+  public required string Name { get; set; }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Infrastructure/EfRepositories/ItemRepository.cs
+++ b/src/TextLifeRpg.Infrastructure/EfRepositories/ItemRepository.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TextLifeRpg.Application.Abstraction.Repositories;
+using TextLifeRpg.Domain;
+using TextLifeRpg.Infrastructure.Mappers;
+
+namespace TextLifeRpg.Infrastructure.EfRepositories;
+
+/// <summary>
+/// Repository for items.
+/// </summary>
+public class ItemRepository(ApplicationContext context) : RepositoryBase(context), IItemRepository
+{
+  #region Implementation of IItemRepository
+
+  /// <inheritdoc />
+  public async Task<Item?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+  {
+    var dataModel = await Context.Items.FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+    return dataModel?.ToDomain();
+  }
+
+  /// <inheritdoc />
+  public async Task<Item?> GetByNameAsync(string name, CancellationToken cancellationToken)
+  {
+    var dataModel = await Context.Items.FirstOrDefaultAsync(t => t.Name == name, cancellationToken);
+
+    return dataModel?.ToDomain();
+  }
+
+  /// <inheritdoc />
+  public async Task<IReadOnlyCollection<Item>> GetAllAsync(CancellationToken cancellationToken)
+  {
+    var dataModels = await Context.Items.ToListAsync(cancellationToken).ConfigureAwait(false);
+
+    return dataModels.ToDomainCollection();
+  }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Infrastructure/JsonDataModels/CharacterDataModel.cs
+++ b/src/TextLifeRpg.Infrastructure/JsonDataModels/CharacterDataModel.cs
@@ -79,5 +79,10 @@ public class CharacterDataModel
   /// </summary>
   public Guid? JobId { get; set; }
 
+  /// <summary>
+  /// Represents the character's inventory entries.
+  /// </summary>
+  public List<InventoryEntryDataModel> InventoryEntries { get; init; } = [];
+
   #endregion
 }

--- a/src/TextLifeRpg.Infrastructure/JsonDataModels/InventoryEntryDataModel.cs
+++ b/src/TextLifeRpg.Infrastructure/JsonDataModels/InventoryEntryDataModel.cs
@@ -1,0 +1,14 @@
+﻿namespace TextLifeRpg.Infrastructure.JsonDataModels;
+
+/// <summary>
+/// JSON data model representing an inventory entry for serialization.
+/// </summary>
+public class InventoryEntryDataModel
+{
+  #region Properties
+
+  public Guid ItemId { get; init; }
+  public int Quantity { get; init; }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Infrastructure/Mappers/CharacterAttributesMapper.cs
+++ b/src/TextLifeRpg.Infrastructure/Mappers/CharacterAttributesMapper.cs
@@ -2,8 +2,11 @@
 using TextLifeRpg.Domain;
 using TextLifeRpg.Infrastructure.JsonDataModels;
 
+namespace TextLifeRpg.Infrastructure.Mappers;
+
 /// <summary>
-///
+/// Mapper for converting between <see cref="CharacterAttributes" /> domain models and <see cref="CharacterAttributesDataModel" /> JSON data
+/// models.
 /// </summary>
 public static class CharacterAttributesMapper
 {
@@ -15,7 +18,6 @@ public static class CharacterAttributesMapper
   public static CharacterAttributes ToDomain(this CharacterAttributesDataModel dataModel)
   {
     return CharacterAttributes.Create(dataModel.Intelligence, dataModel.Strength, dataModel.Charisma);
-    ;
   }
 
   /// <summary>

--- a/src/TextLifeRpg.Infrastructure/Mappers/CharacterMapper.cs
+++ b/src/TextLifeRpg.Infrastructure/Mappers/CharacterMapper.cs
@@ -33,6 +33,8 @@ public static class CharacterMapper
       character.SetJob(dataModel.JobId.Value);
     }
 
+    character.AddInventoryEntries(dataModel.InventoryEntries.ToDomainCollection());
+
     return character;
   }
 
@@ -64,7 +66,8 @@ public static class CharacterMapper
         Energy = u.Energy,
         Money = u.Money,
         Attributes = u.Attributes.ToDataModel(),
-        JobId = u.JobId
+        JobId = u.JobId,
+        InventoryEntries = u.InventoryEntries.ToDataModelCollection()
       }
     );
   }

--- a/src/TextLifeRpg.Infrastructure/Mappers/InventoryEntryMapper.cs
+++ b/src/TextLifeRpg.Infrastructure/Mappers/InventoryEntryMapper.cs
@@ -1,0 +1,52 @@
+﻿using TextLifeRpg.Application.InternalUtilities;
+using TextLifeRpg.Domain;
+using TextLifeRpg.Infrastructure.JsonDataModels;
+
+namespace TextLifeRpg.Infrastructure.Mappers;
+
+/// <summary>
+/// Mapper for converting between <see cref="InventoryEntry" /> domain models and <see cref="InventoryEntryDataModel" /> JSON data models.
+/// </summary>
+public static class InventoryEntryMapper
+{
+  #region Methods
+
+  /// <summary>
+  /// Maps an EF data model to its domain counterpart.
+  /// </summary>
+  public static InventoryEntry ToDomain(this InventoryEntryDataModel dataModel)
+  {
+    return dataModel.Map(i => InventoryEntry.Create(i.ItemId, i.Quantity));
+  }
+
+  /// <summary>
+  /// Maps a collection of EF data models to domain models.
+  /// </summary>
+  public static List<InventoryEntry> ToDomainCollection(this IEnumerable<InventoryEntryDataModel> dataModels)
+  {
+    return dataModels.MapCollection(ToDomain);
+  }
+
+  /// <summary>
+  /// Maps a domain model to its EF data model counterpart.
+  /// </summary>
+  public static InventoryEntryDataModel ToDataModel(this InventoryEntry domain)
+  {
+    return domain.Map(u => new InventoryEntryDataModel
+      {
+        ItemId = u.ItemId,
+        Quantity = u.Quantity
+      }
+    );
+  }
+
+  /// <summary>
+  /// Maps a collection of domain models to a collection of JSON data models.
+  /// </summary>
+  public static List<InventoryEntryDataModel> ToDataModelCollection(this IEnumerable<InventoryEntry> domains)
+  {
+    return domains.MapCollection(ToDataModel);
+  }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Infrastructure/Mappers/ItemMapper.cs
+++ b/src/TextLifeRpg.Infrastructure/Mappers/ItemMapper.cs
@@ -5,24 +5,24 @@ using TextLifeRpg.Infrastructure.EfDataModels;
 namespace TextLifeRpg.Infrastructure.Mappers;
 
 /// <summary>
-/// Mapper for converting between <see cref="Job" /> domain models and <see cref="JobDataModel" /> JSON data models.
+/// Mapper for converting between <see cref="Item" /> domain models and <see cref="ItemDataModel" /> EF data models.
 /// </summary>
-public static class JobMapper
+public static class ItemMapper
 {
   #region Methods
 
   /// <summary>
   /// Maps an EF data model to its domain counterpart.
   /// </summary>
-  public static Job ToDomain(this JobDataModel dataModel)
+  public static Item ToDomain(this ItemDataModel dataModel)
   {
-    return dataModel.Map(i => Job.Load(i.Id, i.Name, i.HourIncome, i.MaxWorkers));
+    return dataModel.Map(i => Item.Load(i.Id, i.Name));
   }
 
   /// <summary>
   /// Maps a collection of EF data models to domain models.
   /// </summary>
-  public static List<Job> ToDomainCollection(this IEnumerable<JobDataModel> dataModels)
+  public static List<Item> ToDomainCollection(this IEnumerable<ItemDataModel> dataModels)
   {
     return dataModels.MapCollection(ToDomain);
   }
@@ -30,14 +30,12 @@ public static class JobMapper
   /// <summary>
   /// Maps a domain model to its EF data model counterpart.
   /// </summary>
-  public static JobDataModel ToDataModel(this Job domain)
+  public static ItemDataModel ToDataModel(this Item domain)
   {
-    return domain.Map(u => new JobDataModel
+    return domain.Map(u => new ItemDataModel
       {
         Id = u.Id,
-        Name = u.Name,
-        HourIncome = u.HourIncome,
-        MaxWorkers = u.MaxWorkers
+        Name = u.Name
       }
     );
   }

--- a/src/TextLifeRpg.Infrastructure/Mappers/TextLineMapper.cs
+++ b/src/TextLifeRpg.Infrastructure/Mappers/TextLineMapper.cs
@@ -4,6 +4,10 @@ using TextLifeRpg.Infrastructure.JsonDataModels;
 
 namespace TextLifeRpg.Infrastructure.Mappers;
 
+/// <summary>
+/// Mapper for converting between <see cref="TextLine" /> domain models
+/// and <see cref="TextLineDataModel" /> JSON data models.
+/// </summary>
 public static class TextLineMapper
 {
   #region Methods

--- a/src/TextLifeRpg.Infrastructure/Seeders/ItemSeeder.cs
+++ b/src/TextLifeRpg.Infrastructure/Seeders/ItemSeeder.cs
@@ -1,0 +1,33 @@
+﻿using TextLifeRpg.Infrastructure.EfDataModels;
+
+namespace TextLifeRpg.Infrastructure.Seeders;
+
+/// <summary>
+/// Item data seeder.
+/// </summary>
+public class ItemSeeder : IDataSeeder
+{
+  #region Implementation of IDataSeeder
+
+  /// <inheritdoc />
+  public async Task SeedAsync(ApplicationContext context)
+  {
+    foreach (var name in new[]
+             {
+               "Student card"
+             })
+    {
+      var item = new ItemDataModel
+      {
+        Id = Guid.NewGuid(),
+        Name = name
+      };
+
+      await context.Items.AddAsync(item).ConfigureAwait(false);
+
+      await context.SaveChangesAsync().ConfigureAwait(false);
+    }
+  }
+
+  #endregion
+}

--- a/src/TextLifeRpg.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/TextLifeRpg.Infrastructure/ServiceCollectionExtensions.cs
@@ -34,6 +34,8 @@ public static class ServiceCollectionExtensions
     services.AddScoped<IExplorationActionResultRepository, ExplorationActionResultRepository>();
     services.AddScoped<IExplorationActionResultNarrationRepository, ExplorationActionResultNarrationRepository>();
     services.AddScoped<IJobRepository, JobRepository>();
+    services.AddScoped<IItemRepository, ItemRepository>();
+
     services.AddScoped<IGameSaveRepository, GameSaveJsonRepository>();
 
     var dataDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data");

--- a/test/TextLifeRpg.Application.Tests/Services/ItemServiceTests.cs
+++ b/test/TextLifeRpg.Application.Tests/Services/ItemServiceTests.cs
@@ -1,0 +1,76 @@
+﻿using TextLifeRpg.Application.Abstraction.Repositories;
+using TextLifeRpg.Application.Services;
+using TextLifeRpg.Domain;
+
+namespace TextLifeRpg.Application.Tests.Services;
+
+public class ItemServiceTests
+{
+  #region Fields
+
+  private readonly IItemRepository _itemRepository = A.Fake<IItemRepository>();
+  private readonly ItemService _itemService;
+
+  #endregion
+
+  #region Ctors
+
+  public ItemServiceTests()
+  {
+    _itemService = new ItemService(_itemRepository);
+  }
+
+  #endregion
+
+  #region Methods
+
+  [Fact]
+  public async Task GetByIdAsync_ShouldCallRepositoryAndReturnResult()
+  {
+    // Arrange
+    var itemId = Guid.NewGuid();
+    var item = Item.Load(itemId, string.Empty);
+    A.CallTo(() => _itemRepository.GetByIdAsync(itemId, A<CancellationToken>._)).Returns(item);
+
+    // Act
+    var result = await _itemService.GetByIdAsync(itemId, CancellationToken.None);
+
+    // Assert
+    Assert.NotNull(result);
+    Assert.Equal(itemId, result.Id);
+  }
+
+  [Fact]
+  public async Task GetByNameAsync_ShouldCallRepositoryAndReturnResult()
+  {
+    // Arrange
+    var itemId = Guid.NewGuid();
+    var item = Item.Load(itemId, string.Empty);
+    A.CallTo(() => _itemRepository.GetByNameAsync(string.Empty, A<CancellationToken>._)).Returns(item);
+
+    // Act
+    var result = await _itemService.GetByNameAsync(string.Empty, CancellationToken.None);
+
+    // Assert
+    Assert.NotNull(result);
+    Assert.Equal(itemId, result.Id);
+  }
+
+  [Fact]
+  public async Task GetAllItemsAsync_ShouldCallRepositoryAndReturnResult()
+  {
+    // Arrange
+    var items = new List<Item> {Item.Load(Guid.NewGuid(), string.Empty)};
+    A.CallTo(() => _itemRepository.GetAllAsync(A<CancellationToken>._)).Returns(items);
+
+    // Act
+    var result = await _itemService.GetAllAsync(CancellationToken.None);
+    var resultList = result.ToList();
+
+    // Assert
+    Assert.Equal(items.Count, resultList.Count);
+    Assert.Equal(items[0].Id, resultList[0].Id);
+  }
+
+  #endregion
+}

--- a/test/TextLifeRpg.Domain.Tests/CharacterTests.cs
+++ b/test/TextLifeRpg.Domain.Tests/CharacterTests.cs
@@ -115,5 +115,85 @@ public class CharacterTests
     Assert.Equal(expectedAge, age);
   }
 
+  [Fact]
+  public void AddItemToInventory_ShouldAddNewEntry_WhenItemNotPresent()
+  {
+    // Arrange
+    var character = new CharacterBuilder().Build();
+    var itemId = Guid.NewGuid();
+
+    // Act
+    character.AddItemToInventory(itemId, 3);
+
+    // Assert
+    var entry = character.InventoryEntries.FirstOrDefault(i => i.ItemId == itemId);
+    Assert.NotNull(entry);
+    Assert.Equal(3, entry.Quantity);
+  }
+
+  [Fact]
+  public void AddItemToInventory_ShouldIncreaseQuantity_WhenItemAlreadyExists()
+  {
+    // Arrange
+    var character = new CharacterBuilder().Build();
+    var itemId = Guid.NewGuid();
+    character.AddItemToInventory(itemId, 2);
+
+    // Act
+    character.AddItemToInventory(itemId, 5);
+
+    // Assert
+    var entry = character.InventoryEntries.FirstOrDefault(i => i.ItemId == itemId);
+    Assert.NotNull(entry);
+    Assert.Equal(7, entry.Quantity);
+  }
+
+  [Fact]
+  public void RemoveItemFromInventory_ShouldDecreaseQuantity_WhenItemExists()
+  {
+    // Arrange
+    var character = new CharacterBuilder().Build();
+    var itemId = Guid.NewGuid();
+    character.AddItemToInventory(itemId, 5);
+
+    // Act
+    character.RemoveItemFromInventory(itemId, 3);
+
+    // Assert
+    var entry = character.InventoryEntries.FirstOrDefault(i => i.ItemId == itemId);
+    Assert.NotNull(entry);
+    Assert.Equal(2, entry.Quantity);
+  }
+
+  [Fact]
+  public void RemoveItemFromInventory_ShouldRemoveEntry_WhenQuantityReachesZero()
+  {
+    // Arrange
+    var character = new CharacterBuilder().Build();
+    var itemId = Guid.NewGuid();
+    character.AddItemToInventory(itemId, 3);
+
+    // Act
+    character.RemoveItemFromInventory(itemId, 3);
+
+    // Assert
+    var entry = character.InventoryEntries.FirstOrDefault(i => i.ItemId == itemId);
+    Assert.Null(entry); // Should be removed
+  }
+
+  [Fact]
+  public void RemoveItemFromInventory_ShouldDoNothing_WhenItemDoesNotExist()
+  {
+    // Arrange
+    var character = new CharacterBuilder().Build();
+    var itemId = Guid.NewGuid();
+
+    // Act
+    character.RemoveItemFromInventory(itemId, 3);
+
+    // Assert
+    Assert.Empty(character.InventoryEntries);
+  }
+
   #endregion
 }

--- a/test/TextLifeRpg.Domain.Tests/InventoryEntryTests.cs
+++ b/test/TextLifeRpg.Domain.Tests/InventoryEntryTests.cs
@@ -1,0 +1,45 @@
+﻿namespace TextLifeRpg.Domain.Tests;
+
+public class InventoryEntryTests
+{
+  [Fact]
+  public void Create_ShouldInitialize()
+  {
+    // Arrange
+    var itemId = Guid.NewGuid();
+
+    // Act
+    var domain = InventoryEntry.Create(itemId, int.MinValue);
+
+    // Assert
+    Assert.NotNull(domain);
+    Assert.Equal(itemId, domain.ItemId);
+    Assert.Equal(int.MinValue, domain.Quantity);
+  }
+
+  [Fact]
+  public void Add_ShouldIncreaseQuantity()
+  {
+    // Arrange
+    var domain = InventoryEntry.Create(Guid.NewGuid(), 2);
+
+    // Act
+    domain.Add(3);
+
+    // Assert
+    Assert.Equal(5, domain.Quantity);
+  }
+
+  [Fact]
+  public void Remove_ShouldDecreaseQuantity()
+  {
+    // Arrange
+    var domain = InventoryEntry.Create(Guid.NewGuid(), 5);
+
+    // Act
+    domain.Remove(3);
+
+    // Assert
+    Assert.Equal(2, domain.Quantity);
+  }
+}

--- a/test/TextLifeRpg.Domain.Tests/ItemTests.cs
+++ b/test/TextLifeRpg.Domain.Tests/ItemTests.cs
@@ -1,0 +1,34 @@
+﻿namespace TextLifeRpg.Domain.Tests;
+
+public class ItemTests
+{
+  #region Methods
+
+  [Fact]
+  public void Create_ShouldInitialize()
+  {
+    // Act
+    var item = Item.Create(string.Empty);
+
+    // Assert
+    Assert.NotNull(item);
+    Assert.NotEqual(Guid.Empty, item.Id);
+    Assert.Equal(string.Empty, item.Name);
+  }
+
+  [Fact]
+  public void Load_ShouldInitializeWithGivenValues()
+  {
+    // Arrange
+    var id = Guid.NewGuid();
+
+    // Act
+    var item = Item.Load(id, string.Empty);
+
+    // Assert
+    Assert.Equal(id, item.Id);
+    Assert.Equal(string.Empty, item.Name);
+  }
+
+  #endregion
+}

--- a/test/TextLifeRpg.Infrastructure.Tests/EfDataModels/ItemDataModelTests.cs
+++ b/test/TextLifeRpg.Infrastructure.Tests/EfDataModels/ItemDataModelTests.cs
@@ -1,0 +1,28 @@
+﻿using TextLifeRpg.Infrastructure.EfDataModels;
+
+namespace TextLifeRpg.Infrastructure.Tests.EfDataModels;
+
+public class ItemDataModelTests
+{
+  #region Methods
+
+  [Fact]
+  public void Instanciation_ShouldInitializeWithGivenValues()
+  {
+    // Arrange
+    var id = Guid.NewGuid();
+
+    // Act
+    var dataModel = new ItemDataModel
+    {
+      Id = id,
+      Name = string.Empty
+    };
+
+    // Assert
+    Assert.Equal(id, dataModel.Id);
+    Assert.Equal(string.Empty, dataModel.Name);
+  }
+
+  #endregion
+}

--- a/test/TextLifeRpg.Infrastructure.Tests/EfRepositories/ItemRepositoryTests.cs
+++ b/test/TextLifeRpg.Infrastructure.Tests/EfRepositories/ItemRepositoryTests.cs
@@ -4,31 +4,31 @@ using TextLifeRpg.Infrastructure.EfRepositories;
 
 namespace TextLifeRpg.Infrastructure.Tests.EfRepositories;
 
-public class JobRepositoryTests
+public class ItemRepositoryTests
 {
   #region Fields
 
-  private readonly List<JobDataModel> _jobs;
-  private readonly JobRepository _repository;
+  private readonly List<ItemDataModel> _items;
+  private readonly ItemRepository _repository;
 
   #endregion
 
   #region Ctors
 
-  public JobRepositoryTests()
+  public ItemRepositoryTests()
   {
     var context = A.Fake<ApplicationContext>();
 
-    _jobs =
+    _items =
     [
-      new JobDataModel {Id = Guid.NewGuid(), Name = "Cashier", HourIncome = int.MinValue, MaxWorkers = int.MinValue},
-      new JobDataModel {Id = Guid.NewGuid(), Name = "Mechanic", HourIncome = int.MinValue, MaxWorkers = int.MinValue}
+      new ItemDataModel {Id = Guid.NewGuid(), Name = "Key"},
+      new ItemDataModel {Id = Guid.NewGuid(), Name = "Badge"}
     ];
 
-    var mockDbSet = _jobs.AsQueryable().BuildMockDbSet();
-    A.CallTo(() => context.Jobs).Returns(mockDbSet);
+    var mockDbSet = _items.AsQueryable().BuildMockDbSet();
+    A.CallTo(() => context.Items).Returns(mockDbSet);
 
-    _repository = new JobRepository(context);
+    _repository = new ItemRepository(context);
   }
 
   #endregion
@@ -36,10 +36,10 @@ public class JobRepositoryTests
   #region Tests
 
   [Fact]
-  public async Task GetById_ShouldReturnMappedJob_WhenItExists()
+  public async Task GetById_ShouldReturnMappedItem_WhenItExists()
   {
     // Arrange
-    var existing = _jobs[1];
+    var existing = _items[1];
 
     // Act
     var result = await _repository.GetByIdAsync(existing.Id, CancellationToken.None);
@@ -51,10 +51,10 @@ public class JobRepositoryTests
   }
 
   [Fact]
-  public async Task GetByNameAsync_ShouldReturnMappedJob_WhenExists()
+  public async Task GetByNameAsync_ShouldReturnMappedItem_WhenExists()
   {
     // Arrange
-    var target = _jobs[1];
+    var target = _items[1];
 
     // Act
     var result = await _repository.GetByNameAsync(target.Name, CancellationToken.None);
@@ -63,7 +63,6 @@ public class JobRepositoryTests
     Assert.NotNull(result);
     Assert.Equal(target.Id, result.Id);
     Assert.Equal(target.Name, result.Name);
-    Assert.Equal(target.HourIncome, result.HourIncome);
   }
 
   [Fact]
@@ -77,15 +76,15 @@ public class JobRepositoryTests
   }
 
   [Fact]
-  public async Task GetAllAsync_ShouldReturnMappedJobs()
+  public async Task GetAllAsync_ShouldReturnMappedItems()
   {
     var result = await _repository.GetAllAsync(CancellationToken.None);
 
     Assert.NotNull(result);
-    Assert.Equal(_jobs.Count, result.Count);
-    foreach (var job in _jobs)
+    Assert.Equal(_items.Count, result.Count);
+    foreach (var item in _items)
     {
-      Assert.Contains(result, r => r.Id == job.Id);
+      Assert.Contains(result, r => r.Id == item.Id);
     }
   }
 

--- a/test/TextLifeRpg.Infrastructure.Tests/Mappers/InventoryEntryMapperTests.cs
+++ b/test/TextLifeRpg.Infrastructure.Tests/Mappers/InventoryEntryMapperTests.cs
@@ -1,0 +1,88 @@
+﻿using TextLifeRpg.Domain;
+using TextLifeRpg.Infrastructure.JsonDataModels;
+using TextLifeRpg.Infrastructure.Mappers;
+
+namespace TextLifeRpg.Infrastructure.Tests.Mappers;
+
+public class InventoryEntryMapperTests
+{
+  #region Methods
+
+  [Fact]
+  public void MapToDomain_ShouldMapDataModelToDomain()
+  {
+    // Arrange
+    var itemId = Guid.NewGuid();
+    var dataModel = new InventoryEntryDataModel
+    {
+      ItemId = itemId,
+      Quantity = int.MinValue
+    };
+
+    // Act
+    var domain = dataModel.ToDomain();
+
+    // Assert
+    Assert.Equal(itemId, domain.ItemId);
+    Assert.Equal(int.MinValue, domain.Quantity);
+  }
+
+  [Fact]
+  public void MapToDomainCollection_ShouldMapDataModelCollectionToDomainCollection()
+  {
+    // Arrange
+    var list = new List<InventoryEntryDataModel>
+    {
+      new() {ItemId = Guid.NewGuid(), Quantity = int.MinValue},
+      new() {ItemId = Guid.NewGuid(), Quantity = int.MinValue}
+    };
+
+    // Act
+    var result = list.ToDomainCollection();
+
+    // Assert
+    Assert.Equal(2, result.Count);
+    Assert.Equal(list[0].ItemId, result[0].ItemId);
+    Assert.Equal(list[0].Quantity, result[0].Quantity);
+    Assert.Equal(list[1].ItemId, result[1].ItemId);
+    Assert.Equal(list[1].Quantity, result[1].Quantity);
+  }
+
+  [Fact]
+  public void MapToDataModel_ShouldMapDomainToDataModel()
+  {
+    // Arrange
+    var itemId = Guid.NewGuid();
+    var domain = InventoryEntry.Create(itemId, int.MinValue);
+
+    // Act
+    var result = domain.ToDataModel();
+
+    // Assert
+    Assert.Equal(itemId, result.ItemId);
+    Assert.Equal(int.MinValue, result.Quantity);
+  }
+
+  [Fact]
+  public void MapToDataModelCollection_ShouldMapDomainCollectionToDataModelCollection()
+  {
+    // Arrange
+    var domains = new List<InventoryEntry>
+    {
+      InventoryEntry.Create(Guid.NewGuid(), int.MinValue),
+      InventoryEntry.Create(Guid.NewGuid(), int.MinValue)
+    };
+
+    // Act
+    var result = domains.ToDataModelCollection();
+
+    // Assert
+    Assert.Equal(2, result.Count);
+    Assert.Equal(domains[0].ItemId, result[0].ItemId);
+    Assert.Equal(domains[0].Quantity, result[0].Quantity);
+    Assert.Equal(domains[1].ItemId, result[1].ItemId);
+    Assert.Equal(domains[1].Quantity, result[1].Quantity);
+  }
+
+  #endregion
+}

--- a/test/TextLifeRpg.Infrastructure.Tests/Mappers/ItemMapperTests.cs
+++ b/test/TextLifeRpg.Infrastructure.Tests/Mappers/ItemMapperTests.cs
@@ -1,0 +1,69 @@
+﻿using TextLifeRpg.Domain;
+using TextLifeRpg.Infrastructure.EfDataModels;
+using TextLifeRpg.Infrastructure.Mappers;
+
+namespace TextLifeRpg.Infrastructure.Tests.Mappers;
+
+public class ItemMapperTests
+{
+  #region Methods
+
+  [Fact]
+  public void MapToDomain_ShouldMapDataModelToDomain()
+  {
+    // Arrange
+    var id = Guid.NewGuid();
+
+    var dataModel = new ItemDataModel
+    {
+      Id = id,
+      Name = string.Empty
+    };
+
+    // Act
+    var domain = dataModel.ToDomain();
+
+    // Assert
+    Assert.Equal(id, domain.Id);
+    Assert.Equal(string.Empty, domain.Name);
+  }
+
+  [Fact]
+  public void MapToDomainCollection_ShouldMapDataModelCollectionToDomainCollection()
+  {
+    // Arrange
+    var dataModels = new List<ItemDataModel>
+    {
+      new() {Id = Guid.NewGuid(), Name = string.Empty},
+      new() {Id = Guid.NewGuid(), Name = string.Empty}
+    };
+
+    // Act
+    var domainModels = dataModels.ToDomainCollection();
+
+    // Assert
+    Assert.Equal(2, domainModels.Count);
+    Assert.Equal(dataModels[0].Id, domainModels[0].Id);
+    Assert.Equal(dataModels[0].Name, domainModels[0].Name);
+    Assert.Equal(dataModels[1].Id, domainModels[1].Id);
+    Assert.Equal(dataModels[1].Name, domainModels[1].Name);
+  }
+
+  [Fact]
+  public void MapToDataModel_ShouldMapDomainToDataModel()
+  {
+    // Arrange
+    var id = Guid.NewGuid();
+
+    var domain = Item.Load(id, string.Empty);
+
+    // Act
+    var dataModel = domain.ToDataModel();
+
+    // Assert
+    Assert.Equal(id, dataModel.Id);
+    Assert.Equal(string.Empty, dataModel.Name);
+  }
+
+  #endregion
+}

--- a/test/TextLifeRpg.Infrastructure.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/TextLifeRpg.Infrastructure.Tests/ServiceCollectionExtensionsTests.cs
@@ -68,6 +68,11 @@ public class ServiceCollectionExtensionsTests
     var jobRepo = provider.GetService<IJobRepository>();
     Assert.NotNull(jobRepo);
     Assert.IsType<JobRepository>(jobRepo);
+
+    // JobRepository
+    var itemRepo = provider.GetService<IItemRepository>();
+    Assert.NotNull(itemRepo);
+    Assert.IsType<ItemRepository>(itemRepo);
   }
 
   #endregion


### PR DESCRIPTION
- Introduced `Item` domain model along with EF Core data model `ItemDataModel`.
- Implemented `ItemMapper` and related unit tests for domain-to-data-model mappings.
- Added `ItemRepository` and `ItemService` with corresponding interfaces for item retrieval and management.
- Integrated item inventory management in `Character` entity, including add/remove item methods and inventory persistence.
- Updated `CharacterMapper` and related tests to support inventory handling.
- Ensured coverage with unit tests for item-related services, mappers, and repositories.